### PR TITLE
Add Python 2.7 compatibility along with 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     matrix:
         - SETUP_CMD='install'
         - SETUP_CMD='test'
+        - PYTHON_VERSION=2.7 SETUP_CMD='test'
 
 matrix:
 

--- a/pysiaf/__init__.py
+++ b/pysiaf/__init__.py
@@ -7,6 +7,8 @@
 
 """
 
+from __future__ import absolute_import, print_function, division
+
 from .version import *
 
 

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -46,6 +46,9 @@ TODO
 
 """
 
+
+from __future__ import absolute_import, print_function, division
+
 import copy
 import os
 import numpy as np
@@ -1119,7 +1122,7 @@ class HstAperture(Aperture):
     _accepted_aperture_types = ['QUAD', 'RECT', 'CIRC']
 
     def __init__(self):
-        super().__init__()
+        super(HstAperture,self).__init__()
         self.observatory = 'HST'
 
     # dictionary that allows to set attributes using JWST naming convention
@@ -1322,7 +1325,7 @@ class HstAperture(Aperture):
             v = np.rad2deg(np.dot(tvs, xyz)) * u.deg.to(u.arcsec)
             return v[1], v[2]
         else:
-            return super().idl_to_tel(XIdl, YIdl, V3IdlYAngle_deg=V3IdlYAngle_deg,
+            return super(HstAperture, self).idl_to_tel(XIdl, YIdl, V3IdlYAngle_deg=V3IdlYAngle_deg,
                                       V2Ref_arcsec=V2Ref_arcsec, V3Ref_arcsec=V3Ref_arcsec)
 
     def set_idl_reference_point(self, v2_ref, v3_ref, verbose=False):
@@ -1425,7 +1428,7 @@ class JwstAperture(Aperture):
     _accepted_aperture_types = 'FULLSCA OSS ROI SUBARRAY SLIT COMPOUND TRANSFORM'.split()
 
     def __init__(self):
-        super().__init__()
+        super(JwstAperture, self).__init__()
         self.observatory = 'JWST'
 
 def linear_transform_model(from_system, to_system, parity, angle_deg):
@@ -1502,7 +1505,7 @@ class NirspecAperture(JwstAperture):
     _accepted_aperture_types = 'FULLSCA OSS ROI SUBARRAY SLIT COMPOUND TRANSFORM'.split()
 
     def __init__(self):
-        super().__init__()
+        super(NirspecAperture, self).__init__()
         self.observatory = 'JWST'
 
     # def __getattribute__(self, item):

--- a/pysiaf/constants.py
+++ b/pysiaf/constants.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function, division
+
 import glob
 import os
 

--- a/pysiaf/iando/read.py
+++ b/pysiaf/iando/read.py
@@ -25,8 +25,6 @@ import os
 from astropy.table import Table
 import lxml.etree as ET
 
-from .. import aperture
-from .. import siaf
 from ..constants import HST_PRD_DATA_ROOT, JWST_PRD_DATA_ROOT, JWST_SOURCE_DATA_ROOT
 
 
@@ -44,6 +42,7 @@ def get_siaf(input_siaf, observatory='JWST'):
         Siaf object
 
     """
+    from pysiaf import siaf # runtime import to avoid circular import on startup
     if type(input_siaf) == str:
         aperture_collection = read_jwst_siaf(filename=input_siaf)
 
@@ -85,6 +84,7 @@ def read_hst_siaf(file=None):#, AperNames=None):
         Dictionary of apertures
 
     """
+    from pysiaf import aperture # runtime import to avoid circular import on startup
     if file is None:
         file = os.path.join(HST_PRD_DATA_ROOT, 'siaf.dat')
 
@@ -267,6 +267,7 @@ def read_jwst_siaf(instrument=None, filename=None, basepath=None):
         dictionary of apertures
 
     """
+    from pysiaf import aperture # runtime import to avoid circular import on startup
     if (filename is None) and (instrument is None):
         raise ValueError('Specify either input instrument or filename')
 

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -22,6 +22,7 @@ References
     (https://github.com/mperrin/jwxml).
 
 """
+from __future__ import absolute_import, print_function, division
 from collections import OrderedDict
 import re
 
@@ -249,7 +250,7 @@ class Siaf(ApertureCollection):
             Alternative method to specify a specific SIAF XML file.
 
         """
-        super().__init__()
+        super(Siaf, self).__init__()
 
         if instrument is None:
             return

--- a/pysiaf/utils/polynomial.py
+++ b/pysiaf/utils/polynomial.py
@@ -12,6 +12,7 @@ References
 
 """
 
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import pylab as pl
 import scipy as sp


### PR DESCRIPTION
This PR makes syntax adjustments to enable `pysiaf` to run on Python 2.7 as well as 3.x.  No changes in algorithms.  Unit tests pass on both 2.7 and 3.6. 

Motivation: While most/all new code should definitely be in Python 3, at least for right now WebbPSF still supports Python 2.7. in particular this is needed because much of the Pandeia ETC has not yet been fully ported to Py3.  So making `pysiaf` work on Python 2 is necessary before it can be used in WebbPSF instead of `jwxml` .  

Assuming you approve @Johannes-Sahlmann, I'd really appreciate if this could be merged in ASAP. @shanosborne has some updates to WebbPSF that rely on `pysiaf` and we're trying to get a new WebbPSF release out next week...