### PR TITLE
Fix RELIC implementation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include RELIC-INFO
+exclude pysiaf/version.py
+
+# Not recommended: Uncomment below to bundle RELIC during `sdist`
+#
+#recursive-include relic *
+#prune relic/.git
+#prune relic/tests

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 import os
-import subprocess
+import pkgutil
 import sys
 from setuptools import setup, find_packages, Extension, Command
 from setuptools.command.test import test as TestCommand
+from subprocess import check_call, CalledProcessError
 
 try:
     from distutils.config import ConfigParser
@@ -23,22 +24,23 @@ URL = metadata.get('url', 'https://www.stsci.edu/')
 LICENSE = metadata.get('license', 'BSD')
 
 
-if os.path.exists('relic'):
-    sys.path.insert(1, 'relic')
-    import relic.release
-else:
+if not pkgutil.find_loader('relic'):
+    relic_local = os.path.exists('relic')
+    relic_submodule = (relic_local and
+                       os.path.exists('.gitmodules') and
+                       not os.listdir('relic'))
     try:
-        import relic.release
-    except ImportError:
-        try:
-            subprocess.check_call(['git', 'clone',
-                                   'https://github.com/jhunkeler/relic.git'])
-            sys.path.insert(1, 'relic')
-            import relic.release
-        except subprocess.CalledProcessError as e:
-            print(e)
-            exit(1)
+        if relic_submodule:
+            check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+        elif not relic_local:
+            check_call(['git', 'clone', 'https://github.com/spacetelescope/relic.git'])
 
+        sys.path.insert(1, 'relic')
+    except CalledProcessError as e:
+        print(e)
+        exit(1)
+
+import relic.release
 
 version = relic.release.get_info()
 relic.release.write_template(version, PACKAGENAME)


### PR DESCRIPTION
The `RELIC-INFO` file needs to be packaged with the `sdist` tarball in order for relic to do its job (outside of a Git repository setting). This PR should take care of the problem. I suggest generating a new tag based on these modifications and push another tarball up to PyPi.

Resolves #17 

