### PR TITLE
more py27 compatibility - add 'from future' imports to additional files

### DIFF
--- a/pysiaf/utils/compare.py
+++ b/pysiaf/utils/compare.py
@@ -13,7 +13,7 @@ References
     https://stackoverflow.com/questions/4527942/comparing-two-dictionaries-in-python/4527957
 
 """
-
+from __future__ import absolute_import, print_function, division
 from collections import OrderedDict
 import os
 import sys

--- a/pysiaf/utils/rotations.py
+++ b/pysiaf/utils/rotations.py
@@ -11,7 +11,7 @@ References
 
 
 """
-
+from __future__ import absolute_import, print_function, division
 
 # from math import *
 import numpy as np

--- a/pysiaf/utils/tools.py
+++ b/pysiaf/utils/tools.py
@@ -12,7 +12,7 @@ References
 
 
 """
-
+from __future__ import absolute_import, print_function, division
 import copy
 import math
 


### PR DESCRIPTION
Adding `from future` imports to a few files that I missed before, to further ensure everything works fine on both 2.7 and 3+. Thanks to @jhunkeler for noticing that I had missed a couple spots before. 