### PR TITLE
Accurate idl to tel

### DIFF
--- a/pysiaf/__init__.py
+++ b/pysiaf/__init__.py
@@ -12,6 +12,6 @@ from .constants import JWST_PRD_VERSION, JWST_PRD_DATA_ROOT, JWST_PRD_DATA_ROOT_
 from .iando import read, write
 from .siaf import Siaf, ApertureCollection
 # from .tests import test_aperture#, test_polynomial
-from .utils import polynomial, rotations, tools
+from .utils import polynomial, rotations, tools, projection
 
-__all__ = ['Aperture', 'HstAperture', 'JwstAperture', 'SIAF', 'JWST_PRD_VERSION', 'JWST_PRD_DATA_ROOT', 'HST_PRD_VERSION', 'HST_PRD_DATA_ROOT', '_JWST_STAGING_ROOT', 'siaf', 'iando', 'polynomial', 'rotations', 'tools', 'compare', 'JWST_PRD_DATA_ROOT_EXCEL', 'generate', 'tools2']
+__all__ = ['Aperture', 'HstAperture', 'JwstAperture', 'SIAF', 'JWST_PRD_VERSION', 'JWST_PRD_DATA_ROOT', 'HST_PRD_VERSION', 'HST_PRD_DATA_ROOT', '_JWST_STAGING_ROOT', 'siaf', 'iando', 'polynomial', 'rotations', 'tools', 'compare', 'JWST_PRD_DATA_ROOT_EXCEL', 'generate', 'projection']

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -802,25 +802,39 @@ class Aperture(object):
                                                                           YSci - self.YSciRef)
 
     def idl_to_tel(self, XIdl, YIdl, V3IdlYAngle_deg=None, V2Ref_arcsec=None, V3Ref_arcsec=None, method='planar_approximation', input_coordinates='tangent_plane'):
-        """
-        Convert idl to  tel
+        """Convert from ideal to telescope (V2/V3) coordinate system.
 
-        input in arcsec, output in arcsec
-
-        WARNING
-        --------
-        This is an implementation of the planar approximation, which is adequate for most
+        By default, this implementats the planar approximation, which is adequate for most
         purposes but may not be for all. Error is about 1.7 mas at 10 arcminutes from the tangent
         point. See JWST-STScI-1550 for more details.
+        For higher accuracy, set method='spherical_transformation' in which case 3D matrix rotations
+        are applied.
 
-        :param XIdl:
-        :param YIdl:
-        :param V3IdlYAngle_deg:
-        :param V2Ref_arcsec:
-        :param V3Ref_arcsec:
-        :return:
+        Also by default, the input coordinates are in a tangent plane with a reference points at the
+        origin (0,0) of the ideal frame.
+
+        Parameters
+        ----------
+        XIdl: float
+            ideal X coordinate in arcsec
+        YIdl: float
+            ideal Y coordinate in arcsec
+        V3IdlYAngle_deg: float
+            overwrites self.V3IdlYAngle
+        V2Ref_arcsec : float
+            overwrites self.V2Ref
+        V3Ref_arcsec : float
+            overwrites self.V3Ref
+        method : str
+            must be one of ['planar_approximation', 'spherical_transformation']
+        input_coordinates : str
+            must be one of ['tangent_plane', 'spherical']
+
+        Returns
+        -------
+            tuple of floats containing V2, V3 coordinates in arcsec
+
         """
-
         if method == 'planar_approximation':
             if input_coordinates != 'tangent_plane':
                 raise RuntimeError('Output has to be in tangent plane.')
@@ -856,7 +870,6 @@ class Aperture(object):
             # rotated_vector[0] = -1*rotated_vector[0]
             # rotated_vector[1] = self.VIdlParity * rotated_vector[1]
             v2, v3 = rotations.v2v3(rotated_vector)
-
 
         if self._correct_dva:
             return self.correct_for_dva(v2, v3)

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -833,24 +833,38 @@ class Aperture(object):
             return v2, v3
 
     def tel_to_idl(self, V2, V3, V3IdlYAngle_deg=None, V2Ref_arcsec=None, V3Ref_arcsec=None, method='planar_approximation', output_coordinates='tangent_plane'):
-        """Convert tel to idl.
+        """Convert from telescope (V2/V3) to ideal coordinate system.
 
-        input in arcsec, output in arcsec
-
-        This transformation involves going from global V2,V3 to local angles with respect to some
-        reference point, and possibly rotating the axes and/or flipping the parity of the X axis.
-
-
-        WARNING
-        --------
-        This is an implementation of the planar approximation, which is adequate for most
+        By default, this implementats the planar approximation, which is adequate for most
         purposes but may not be for all. Error is about 1.7 mas at 10 arcminutes from the tangent
         point. See JWST-STScI-1550 for more details.
+        For higher accuracy, set method='spherical_transformation' in which case 3D matrix rotations
+        are applied.
 
-        :param V2:
-        :param V3:
-        :param V3IdlYAngle_deg:
-        :return:
+        Also by default, the output coordinates are in a tangent plane with a reference points at the
+        origin (0,0) of the ideal frame.
+
+        Parameters
+        ----------
+        V2 : float
+            V2 coordinate in arcsec
+        V3 : float
+            V2 coordinate in arcsec
+        V3IdlYAngle_deg : float
+            overwrites self.V3IdlYAngle
+        V2Ref_arcsec : float
+            overwrites self.V2Ref
+        V3Ref_arcsec : float
+            overwrites self.V3Ref
+        method : str
+            must be one of ['planar_approximation', 'spherical_transformation']
+        output_coordinates : str
+            must be one of ['tangent_plane', 'spherical']
+
+        Returns
+        -------
+            tuple of floats containing x_idl, y_idl coordinates in arcsec
+
         """
         if V2Ref_arcsec is None:
             V2Ref_arcsec = self.V2Ref

--- a/pysiaf/tests/test_aperture.py
+++ b/pysiaf/tests/test_aperture.py
@@ -40,24 +40,10 @@ def test_idl_to_tel():
     """Test the transformations between ideal and telescope frames that do not use the planar approximation."""
 
     siaf = Siaf('NIRISS')
-    aperture = siaf['NIS_CEN']
 
     x_idl, y_idl = get_grid_coordinates(10, (0, 0), 100)
 
     verbose = False
-    if 0:
-        x_idl = 10
-        y_idl = 10
-
-        v2_0, v3_0 = aperture.idl_to_tel(x_idl, y_idl)
-        v2, v3 = aperture.idl_to_tel(x_idl, y_idl, method='spherical_transformation')
-        x_idl_2, y_idl_2 = aperture.tel_to_idl(v2, v3, method='spherical_transformation')
-
-        print('')
-        print('idl: input {} {}'.format(x_idl, y_idl))
-        print('tel: Planar   : {} {}'.format(v2_0, v3_0))
-        print('tel: Spherical: {} {}'.format(v2, v3))
-        print('idl: output {} {}'.format(x_idl_2, y_idl_2))
 
     for aper_name in siaf.apertures.keys():
         # aperture

--- a/pysiaf/tests/test_projection.py
+++ b/pysiaf/tests/test_projection.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+"""Tests for the pysiaf projection functions.
+
+Authors
+-------
+
+    Johannes Sahlmann
+
+"""
+
+import numpy as np
+import pytest
+
+import astropy.units as u
+
+
+# from ..aperture import HstAperture
+# from ..iando import read
+# from ..siaf import Siaf, get_jwst_apertures
+from ..utils.tools import get_grid_coordinates
+from ..utils import projection
+
+
+
+# x_reference_spherical_deg = 0. * u.deg
+# y_reference_spherical_deg = np.double(0.1) * u.deg
+# x_reference_spherical_deg = 40. * u.deg
+# y_reference_spherical_deg = 70.1 * u.deg
+
+
+
+
+@pytest.fixture(scope='module')
+def grid_coordinates(centre_deg=(0., 0.)):
+    """Return tuple of coordinates in deg mapping out a regular grid
+
+    """
+    n_side = 50
+    span = 20 * u.arcmin
+
+    x_width = span.to(u.deg).value
+
+    return get_grid_coordinates(n_side, centre_deg, x_width)
+
+
+def test_tangent_plane_projection_roundtrip():
+    """Transform from RA/Dec to tangent plane and back. check that input coordinates are recovered."""
+
+    # scale = 1.
+
+    centre_deg = (80., -70.)
+    ra_deg, dec_deg = grid_coordinates(centre_deg=centre_deg)
+
+    # project to detector pixel coordinates
+    x, y = projection.project_to_tangent_plane(ra_deg, dec_deg, centre_deg[0], centre_deg[1])
+
+    # deproject
+    ra, dec = projection.deproject_from_tangent_plane(x, y, centre_deg[0], centre_deg[1])
+
+    difference_modulus = np.sqrt((ra_deg - ra) ** 2 + (dec_deg - dec) ** 2)
+
+    assert np.std(difference_modulus) < 1.e-13 #, 'Problem with tangent plane projection.')
+
+
+
+# """A collection of functions to support tangent-plane de-/projections.
+#
+#
+# Authors
+# -------
+#
+#     - Colin Cox (originally in tancalc.py)
+#     - Johannes Sahlmann
+#
+# References
+# ----------
+#
+# """
+#
+# import numpy as np
+#
+# def project_to_tangent_plane(alpha, delta, alpha_ref, delta_ref):
+#     """Project alpha, delta to tangent plane with reference point at alpha_ref, delta_ref.
+#
+#     Parameters
+#     ----------
+#     alpha : float
+#         angle (e.g. RA) in decimal np.rad2deg
+#     delta : float
+#         angle (e.g. Dec) in decimal np.rad2deg
+#     alpha_ref: float
+#         angle
+#     delta_ref: float
+#         angle
+#
+#     Returns
+#     -------
+#
+#     """
+#     a0 = np.deg2rad(alpha_ref)
+#     d0 = np.deg2rad(delta_ref)
+#     a = np.deg2rad(alpha)
+#     d = np.deg2rad(delta)
+#
+#     cosrho = np.cos(a-a0)*np.cos(d)*np.cos(d0) + np.sin(d)*np.sin(d0)
+#
+#     if np.any(cosrho < 0.01): # angle > 89 deg
+#         raise RuntimeError('Too far from tangent point')
+#
+#     e_rad = np.cos(d)*np.sin(a-a0)/cosrho
+#     n_rad = (np.sin(d)/cosrho - np.sin(d0))/np.cos(d0)
+#
+#     e = np.rad2deg(e_rad)
+#     n = np.rad2deg(n_rad)
+#
+#     return (e, n)
+#
+#
+# def deproject_from_tangent_plane(e, n, alpha_ref, delta_ref):
+#     """Deproject e, n from tangent plane with reference point at alpha_ref, delta_ref.
+#
+#     Parameters
+#     ----------
+#     e : float
+#         tangent plane coordinate
+#     n : float
+#         tangent plane coordinate
+#     alpha_ref
+#     delta_ref
+#
+#     Returns
+#     -------
+#
+#     """
+#
+#     # a0 = np.deg2rad(alpha_ref)
+#     d0 = np.deg2rad(delta_ref)
+#
+#     s = np.hypot(e ,n)
+#     rho = np.arctan(np.deg2rad(s))
+#     B = np.arctan2(e ,n)
+#
+#     dalpha = np.arctan2(np.sin(B)*np.sin(rho), np.cos(rho)*np.cos(d0) - np.sin(rho)*np.sin(d0)*np.cos(B))
+#     alpha = alpha_ref + np.rad2deg(dalpha)
+#
+#     if np.any(alpha < 0.0):
+#         index = np.where(alpha < 0.0)
+#         alpha[index] += 360.0    # set to range 0 to 360 deg
+#
+#     delta_rad = np.arcsin(np.sin(d0)*np.cos(rho) + np.cos(d0)*np.sin(rho)*np.cos(B))
+#     delta = np.rad2deg(delta_rad)
+#
+#     return (alpha, delta)

--- a/pysiaf/tests/test_projection.py
+++ b/pysiaf/tests/test_projection.py
@@ -13,42 +13,23 @@ import pytest
 
 import astropy.units as u
 
-
-# from ..aperture import HstAperture
-# from ..iando import read
-# from ..siaf import Siaf, get_jwst_apertures
 from ..utils.tools import get_grid_coordinates
 from ..utils import projection
 
 
-
-# x_reference_spherical_deg = 0. * u.deg
-# y_reference_spherical_deg = np.double(0.1) * u.deg
-# x_reference_spherical_deg = 40. * u.deg
-# y_reference_spherical_deg = 70.1 * u.deg
-
-
-
-
 @pytest.fixture(scope='module')
 def grid_coordinates(centre_deg=(0., 0.)):
-    """Return tuple of coordinates in deg mapping out a regular grid
-
-    """
+    """Return tuple of coordinates in deg mapping out a regular grid."""
     n_side = 50
     span = 20 * u.arcmin
-
     x_width = span.to(u.deg).value
 
     return get_grid_coordinates(n_side, centre_deg, x_width)
 
 
 def test_tangent_plane_projection_roundtrip():
-    """Transform from RA/Dec to tangent plane and back. check that input coordinates are recovered."""
-
-    # scale = 1.
-
-    centre_deg = (80., -70.)
+    """Transform from RA/Dec to tangent plane and back. Check that input is recovered."""
+    centre_deg = (80., -70.)   # setting this to 0,0 fails because of 0,360 deg wrapping
     ra_deg, dec_deg = grid_coordinates(centre_deg=centre_deg)
 
     # project to detector pixel coordinates
@@ -62,92 +43,110 @@ def test_tangent_plane_projection_roundtrip():
     assert np.std(difference_modulus) < 1.e-13 #, 'Problem with tangent plane projection.')
 
 
+def test_project_to_tangent_plane():
+    """Compare projection code built with astropy functions with independent implementation."""
+    centre_deg = (80., -70.)  # setting this to 0,0 fails because of 0,360 deg wrapping
+    ra_deg, dec_deg = grid_coordinates(centre_deg=centre_deg)
 
-# """A collection of functions to support tangent-plane de-/projections.
-#
-#
-# Authors
-# -------
-#
-#     - Colin Cox (originally in tancalc.py)
-#     - Johannes Sahlmann
-#
-# References
-# ----------
-#
-# """
-#
-# import numpy as np
-#
-# def project_to_tangent_plane(alpha, delta, alpha_ref, delta_ref):
-#     """Project alpha, delta to tangent plane with reference point at alpha_ref, delta_ref.
-#
-#     Parameters
-#     ----------
-#     alpha : float
-#         angle (e.g. RA) in decimal np.rad2deg
-#     delta : float
-#         angle (e.g. Dec) in decimal np.rad2deg
-#     alpha_ref: float
-#         angle
-#     delta_ref: float
-#         angle
-#
-#     Returns
-#     -------
-#
-#     """
-#     a0 = np.deg2rad(alpha_ref)
-#     d0 = np.deg2rad(delta_ref)
-#     a = np.deg2rad(alpha)
-#     d = np.deg2rad(delta)
-#
-#     cosrho = np.cos(a-a0)*np.cos(d)*np.cos(d0) + np.sin(d)*np.sin(d0)
-#
-#     if np.any(cosrho < 0.01): # angle > 89 deg
-#         raise RuntimeError('Too far from tangent point')
-#
-#     e_rad = np.cos(d)*np.sin(a-a0)/cosrho
-#     n_rad = (np.sin(d)/cosrho - np.sin(d0))/np.cos(d0)
-#
-#     e = np.rad2deg(e_rad)
-#     n = np.rad2deg(n_rad)
-#
-#     return (e, n)
-#
-#
-# def deproject_from_tangent_plane(e, n, alpha_ref, delta_ref):
-#     """Deproject e, n from tangent plane with reference point at alpha_ref, delta_ref.
-#
-#     Parameters
-#     ----------
-#     e : float
-#         tangent plane coordinate
-#     n : float
-#         tangent plane coordinate
-#     alpha_ref
-#     delta_ref
-#
-#     Returns
-#     -------
-#
-#     """
-#
-#     # a0 = np.deg2rad(alpha_ref)
-#     d0 = np.deg2rad(delta_ref)
-#
-#     s = np.hypot(e ,n)
-#     rho = np.arctan(np.deg2rad(s))
-#     B = np.arctan2(e ,n)
-#
-#     dalpha = np.arctan2(np.sin(B)*np.sin(rho), np.cos(rho)*np.cos(d0) - np.sin(rho)*np.sin(d0)*np.cos(B))
-#     alpha = alpha_ref + np.rad2deg(dalpha)
-#
-#     if np.any(alpha < 0.0):
-#         index = np.where(alpha < 0.0)
-#         alpha[index] += 360.0    # set to range 0 to 360 deg
-#
-#     delta_rad = np.arcsin(np.sin(d0)*np.cos(rho) + np.cos(d0)*np.sin(rho)*np.cos(B))
-#     delta = np.rad2deg(delta_rad)
-#
-#     return (alpha, delta)
+    x_1, y_1 = projection.project_to_tangent_plane(ra_deg, dec_deg, centre_deg[0], centre_deg[1])
+    x_2, y_2 = tangent_plane_projection(ra_deg, dec_deg, centre_deg[0], centre_deg[1])
+
+    difference_modulus = np.sqrt((x_1 - x_2) ** 2 + (y_1 - y_2) ** 2)
+
+    assert np.max(difference_modulus) < 1e-13
+
+
+def test_deproject_from_tangent_plane():
+    """Compare projection code built with astropy functions with independent implementation."""
+    centre_deg = (80., -70.)  # setting this to 0,0 fails because of 0,360 deg wrapping
+    ra_deg, dec_deg = grid_coordinates(centre_deg=centre_deg)
+
+    x, y = projection.project_to_tangent_plane(ra_deg, dec_deg, centre_deg[0], centre_deg[1])
+
+    ra_1, dec_1 = projection.deproject_from_tangent_plane(x, y, centre_deg[0], centre_deg[1])
+    ra_2, dec_2 = tangent_plane_deprojection(x, y, centre_deg[0], centre_deg[1])
+
+    difference_modulus = np.sqrt((ra_1 - ra_2) ** 2 + (dec_1 - dec_2) ** 2)
+
+    assert np.max(difference_modulus) < 1e-13
+
+
+def tangent_plane_projection(alpha, delta, alpha_ref, delta_ref):
+    """Project alpha, delta to tangent plane with reference point at alpha_ref, delta_ref.
+
+    Alternative, direct implementation based on Colin Cox's tanproj function in tancalc.py
+
+    Parameters
+    ----------
+    alpha : float
+        angle (e.g. RA) in decimal deg
+    delta : float
+        angle (e.g. Dec) in decimal deg
+    alpha_ref: float
+        angle
+    delta_ref: float
+        angle
+
+    Returns
+    -------
+    (e, n) : tuple
+        Tangent plane coordinates
+
+    """
+    a0 = np.deg2rad(alpha_ref)
+    d0 = np.deg2rad(delta_ref)
+    a = np.deg2rad(alpha)
+    d = np.deg2rad(delta)
+
+    cosrho = np.cos(a-a0)*np.cos(d)*np.cos(d0) + np.sin(d)*np.sin(d0)
+
+    if np.any(cosrho < 0.01): # angle > 89 deg
+        raise RuntimeError('Too far from tangent point')
+
+    e_rad = np.cos(d)*np.sin(a-a0)/cosrho
+    n_rad = (np.sin(d)/cosrho - np.sin(d0))/np.cos(d0)
+
+    e = np.rad2deg(e_rad)
+    n = np.rad2deg(n_rad)
+
+    return (e, n)
+
+
+def tangent_plane_deprojection(e, n, alpha_ref, delta_ref):
+    """Deproject e, n from tangent plane with reference point at alpha_ref, delta_ref.
+
+    Alternative, direct implementation based on Colin Cox's invproj function in tancalc.py
+
+    Parameters
+    ----------
+    e : float
+        tangent plane coordinate
+    n : float
+        tangent plane coordinate
+    alpha_ref
+    delta_ref
+
+    Returns
+    -------
+    (alpha, delta) : tuple
+        RA and Dec
+
+    """
+    d0 = np.deg2rad(delta_ref)
+
+    s = np.hypot(e, n)
+    rho = np.arctan(np.deg2rad(s))
+    B = np.arctan2(e, n)
+
+    dalpha = np.arctan2(np.sin(B)*np.sin(rho), np.cos(rho)*np.cos(d0)
+                        - np.sin(rho)*np.sin(d0)*np.cos(B))
+    alpha = alpha_ref + np.rad2deg(dalpha)
+
+    if np.any(alpha < 0.0):
+        index = np.where(alpha < 0.0)
+        alpha[index] += 360.0    # set to range 0 to 360 deg
+
+    delta_rad = np.arcsin(np.sin(d0)*np.cos(rho) + np.cos(d0)*np.sin(rho)*np.cos(B))
+    delta = np.rad2deg(delta_rad)
+
+    return (alpha, delta)

--- a/pysiaf/utils/projection.py
+++ b/pysiaf/utils/projection.py
@@ -1,0 +1,104 @@
+"""A collection of functions to support tangent-plane de-/projections.
+
+Authors
+-------
+
+    Johannes Sahlmann
+
+Use
+---
+
+"""
+
+from astropy.modeling import models as astmodels
+from astropy.modeling import rotations as astrotations
+
+def project_to_tangent_plane(ra, dec, ra_ref, dec_ref, scale=1.):
+    """
+    Convert ra/dec coordinates into pixel coordinates using a tangent plane projection. The projection's reference point has to be specified.
+    Scale is a convenience parameter that defaults to 1.0, in which case the returned pixel coordinates are also in degree. Scale can be set to a pixel scale to return detector coordinates in pixels
+
+    Parameters
+    ----------
+    ra : float
+        Right Ascension in decimal degrees
+    dec: float
+        declination in decimal degrees
+    ra_ref : float
+        Right Ascension of reference point in decimal degrees
+    dec_ref: float
+        declination of reference point in decimal degrees
+    scale : float
+        Multiplicative factor that is applied to the returned values. Default is 1.0
+
+    Returns
+    -------
+	x,y : float
+	   pixel coordinates in decimal degrees if scale = 1.0
+
+    """
+
+    # for zenithal projections, i.e. gnomonic, i.e. TAN:
+    lonpole = 180.
+
+    # tangent plane projection from phi/theta to x,y
+    tan = astmodels.Sky2Pix_TAN()
+
+    # compute native coordinate rotation to obtain phi and theta
+    rot_for_tan = astrotations.RotateCelestial2Native(ra_ref, dec_ref, lonpole)
+
+    phi_theta = rot_for_tan(ra, dec)
+
+    # pixel coordinates,  x and y are in degree-equivalent
+    x, y = tan(phi_theta[0], phi_theta[1])
+
+    x = x * scale
+    y = y * scale
+
+    return x, y
+
+
+def deproject_from_tangent_plane(x, y, ra_ref, dec_ref, scale=1.):
+    """
+    Convert pixel coordinates into ra/dec coordinates using a tangent plane de-projection. The projection's reference point has to be specified.
+    See the inverse transformation radec2Pix_TAN.
+
+    Parameters
+    ----------
+    x : float
+        Pixel coordinate (default is in decimal degrees, but depends on value of scale parameter) x/scale has to be degrees.
+    y : float
+        Pixel coordinate (default is in decimal degrees, but depends on value of scale parameter) x/scale has to be degrees.
+    ra_ref : float
+        Right Ascension of reference point in decimal degrees
+    dec_ref: float
+        declination of reference point in decimal degrees
+    scale : float
+        Multiplicative factor that is applied to the input values. Default is 1.0
+
+	Returns
+    -------
+    ra : float
+        Right Ascension in decimal degrees
+    dec: float
+        declination in decimal degrees
+
+    """
+    # for zenithal projections, i.e. gnomonic, i.e. TAN
+    lonpole = 180.
+
+    x = x / scale
+    y = y / scale
+
+    # tangent plane projection from x,y to phi/theta
+    tan = astmodels.Pix2Sky_TAN()
+
+    # compute native coordinate rotation to obtain ra and dec
+    rot_for_tan = astrotations.RotateNative2Celestial(ra_ref, dec_ref, lonpole)
+
+    phi, theta = tan(x, y)
+
+    # ra and dec
+    ra, dec = rot_for_tan(phi, theta)
+
+    return ra, dec


### PR DESCRIPTION
Adds options to aperture.idl_to_tel and aperture tel_to_idl that allow the use of more accurate prescriptions that do not rely on the planar approximation.
This PR also introduces the projection tools which implement tangent-plane de-/projection.