### PR TITLE
Verify AperType before plotting

### DIFF
--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -484,6 +484,9 @@ class Aperture(object):
         #             error('Please provide attitude_ref')
 
         """
+        if self.AperType == "TRANSFORM":
+            raise TypeError("Cannot plot aperture of type: TRANSFORM")
+
         if units is None:
             units = 'arcsec'
 

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -352,6 +352,8 @@ class Siaf(ApertureCollection):
             iterable = self._getFullApertures
 
         for ap in iterable():
+            if ap.AperType == "TRANSFORM":
+                continue
             if names is not None:
                 if ap.AperName not in names: continue
 


### PR DESCRIPTION
Added checks in siaf.py plot() and aperture.py plot() so that if the aperture has type TRANSFORM, the aperture will be skipped or raise an error (respectively). Fixes issue #48 