### PR TITLE
Plotting updates

### DIFF
--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -643,7 +643,7 @@ class Aperture(object):
             c1, c2 = self.convert(0, 0, 'raw', frame)
             ax.plot(c1 * scale, c2 * scale, color='black', marker='s', markersize=5)
 
-    def plot_detector_channels(self, frame, color='0.5', alpha=0.3, evenoddratio=0.5):
+    def plot_detector_channels(self, frame, color='0.5', alpha=0.3, evenoddratio=0.5, ax=None):
         """Outline the detector readout channels.
 
         These are depicted as alternating light/dark bars to show the
@@ -662,12 +662,17 @@ class Aperture(object):
         evenoddratio : float
             Ratio of opacity between even and odd amplifier region
             overlays
+        ax : matplotlib.Axes
+            Desired destination axes to plot into (If None, current
+            axes are inferred from pyplot.)
 
         """
         npixels = self.XDetSize
         ch = npixels / 4
 
-        ax = pl.gca()
+        if ax is None:
+            ax = pl.gca()
+
         if self.InstrName in ['NIRISS', 'FGS', 'NIRSPEC']:
             pts = ((0, 0), (0, ch), (npixels, ch), (npixels, 0))
         else:

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -667,7 +667,19 @@ class Aperture(object):
             axes are inferred from pyplot.)
 
         """
-        npixels = self.XDetSize
+
+        # NIRSpec MSA requires plotting underlying channels
+        msa_dict = {"NRS_FULL_MSA1": "NRS2_FULL", "NRS_FULL_MSA2": "NRS2_FULL",
+                    "NRS_FULL_MSA3": "NRS1_FULL", "NRS_FULL_MSA4": "NRS1_FULL",
+                    "NRS_S1600A1_SLIT": "NRS1_FULL"}
+
+        if self.AperName not in msa_dict.keys():
+            npixels = self.XDetSize
+        else:
+            aper = msa_dict[self.AperName]
+            nrs = read.read_jwst_siaf(self.InstrName)[aper]
+            npixels = nrs.XDetSize
+
         ch = npixels / 4
 
         if ax is None:

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -484,7 +484,7 @@ class Aperture(object):
         """
         return matplotlib.path.Path(np.array(self.closed_polygon_points(to_frame)).T)
 
-    def plot(self, frame='tel', name_label=None, ax=None, title=False, units='arcsec',
+    def plot(self, frame='tel', label=False, ax=None, title=False, units='arcsec',
              show_frame_origin=None, mark_ref=False, fill=True, fill_color='cyan', fill_alpha=None,
              **kwargs):
         """Plot this aperture.
@@ -493,9 +493,8 @@ class Aperture(object):
         ----------
         frame : str
             Which coordinate system to plot in: 'tel', 'idl', 'sci', 'det'
-        name_label : str
-            Add text label stating aperture name. If given 'default' will plot the aperture
-            names.
+        label : str or bool
+            Add text label. If True, text will be the default aperture name.
         ax : matplotlib.Axes
             Desired destination axes to plot into (If None, current
             axes are inferred from pylab)
@@ -566,14 +565,14 @@ class Aperture(object):
 
         ax.plot(x2 * scale, y2 * scale, **kwargs)
 
-        if name_label is not None:
+        if label is not False:
             rotation = 0
-            if name_label == 'default':
+            if label is True:
                 # partially mitigate overlapping NIRCam labels
                 rotation = 30 if self.AperName.startswith('NRC') else 0
-                name_label = self.AperName
+                label = self.AperName
             ax.text(
-                x.mean() * scale, y.mean() * scale, name_label,
+                x.mean() * scale, y.mean() * scale, label,
                 verticalalignment='center',
                 horizontalalignment='center',
                 rotation=rotation,

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -131,7 +131,7 @@ def get_jwst_apertures(apertures_dict, include_oss_apertures=False, exact_patter
 def plot_all_apertures(subarrays=True, showorigin=True, detector_channels=True, **kwargs):
     """Plot all apertures."""
     for instr in ['NIRCam', 'NIRISS', 'NIRSpec', 'FGS', 'MIRI']:
-        aps = Siaf(instr, **kwargs)
+        aps = Siaf(instr)
         print("{0} has {1} apertures".format(aps.instrument, len(aps)))
 
         aps.plot(clear=False, subarrays=subarrays, **kwargs)

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -385,12 +385,7 @@ class Siaf(ApertureCollection):
                 if ap.AperName not in names:
                     continue
 
-            if label is True:
-                name_label = ap.AperName
-            else:
-                name_label= None
-
-            ap.plot(frame=frame, name_label=name_label, ax=ax, units=units, mark_ref=mark_ref,
+            ap.plot(frame=frame, label=label, ax=ax, units=units, mark_ref=mark_ref,
                     show_frame_origin=show_frame_origin, **kwargs)
 
         if frame == 'Tel' or frame == 'Idl':

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -441,12 +441,17 @@ class Siaf(ApertureCollection):
             axes are inferred from pyplot.)
 
         """
-        raise NotImplementedError
         # raise NotImplementedError
         if ax is None:
             ax = pl.gca()
 
         if frame is None:
             frame = self._last_plot_frame
-        for ap in self._getFullApertures():
-            ap.plot_detector_channels(frame=frame)
+
+        if self.instrument == "nirspec":
+            aper_list = [self.apertures['NRS1_FULL'], self.apertures['NRS2_FULL']]
+        else:
+            aper_list = self._getFullApertures()
+
+        for ap in aper_list:
+            ap.plot_detector_channels(frame=frame, ax=ax)

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -192,7 +192,7 @@ def plot_main_apertures(label=False, darkbg=False, detector_channels=False, **kw
 
     for aplist, col in zip([im_aps, coron_aps, msa_aps], [col_imaging, col_coron, col_msa]):
         for ap in aplist:
-            ap.plot(color=col, frame='tel', name_label=label, **kwargs)
+            ap.plot(color=col, frame='tel', label=label, **kwargs)
             if detector_channels:
                 try:
                     ap.plot_detector_channels('tel')
@@ -335,7 +335,7 @@ class Siaf(ApertureCollection):
         """List of aperture names defined in this SIAF."""
         return self.apertures.keys()
 
-    def plot(self, frame='tel', names=None, label=None, units=None, clear=True,
+    def plot(self, frame='tel', names=None, label=False, units=None, clear=True,
              show_frame_origin=None, mark_ref=False, subarrays=True, ax=None, **kwargs):
         """Plot all apertures in this SIAF.
 

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -424,7 +424,7 @@ class Siaf(ApertureCollection):
         for ap in self._getFullApertures():
             ap.plot_frame_origin(frame=frame, which=which, units=units, ax=ax)
 
-    def plot_detector_channels(self, frame=None):
+    def plot_detector_channels(self, frame=None, ax=None):
         """Mark on the plot the various detector readout channels.
 
         These are depicted as alternating light/dark bars to show the
@@ -436,9 +436,15 @@ class Siaf(ApertureCollection):
             Which coordinate system to plot in: 'Tel', 'Idl', 'Sci', 'Det'
             Optional if you have already called plot() to specify a
             coordinate frame.
+        ax : matplotlib.Axes
+            Desired destination axes to plot into (If None, current
+            axes are inferred from pyplot.)
 
         """
         raise NotImplementedError
+        # raise NotImplementedError
+        if ax is None:
+            ax = pl.gca()
 
         if frame is None:
             frame = self._last_plot_frame

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -441,17 +441,12 @@ class Siaf(ApertureCollection):
             axes are inferred from pyplot.)
 
         """
-        # raise NotImplementedError
+
         if ax is None:
             ax = pl.gca()
 
         if frame is None:
             frame = self._last_plot_frame
 
-        if self.instrument == "nirspec":
-            aper_list = [self.apertures['NRS1_FULL'], self.apertures['NRS2_FULL']]
-        else:
-            aper_list = self._getFullApertures()
-
-        for ap in aper_list:
+        for ap in self._getFullApertures():
             ap.plot_detector_channels(frame=frame, ax=ax)

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -128,7 +128,7 @@ def get_jwst_apertures(apertures_dict, include_oss_apertures=False, exact_patter
     return ApertureCollection(aperture_dict=all_aps)
 
 
-def plot_all_apertures(subarrays=True, showorigin=True, showchannels=True, **kwargs):
+def plot_all_apertures(subarrays=True, showorigin=True, detector_channels=True, **kwargs):
     """Plot all apertures."""
     for instr in ['NIRCam', 'NIRISS', 'NIRSpec', 'FGS', 'MIRI']:
         aps = Siaf(instr, **kwargs)
@@ -137,7 +137,7 @@ def plot_all_apertures(subarrays=True, showorigin=True, showchannels=True, **kwa
         aps.plot(clear=False, subarrays=subarrays, **kwargs)
         if showorigin:
             aps.plot_frame_origin()
-        if showchannels:
+        if detector_channels:
             aps.plot_detector_channels()
 
 

--- a/pysiaf/tests/test_projection.py
+++ b/pysiaf/tests/test_projection.py
@@ -18,16 +18,18 @@ from ..utils import projection
 
 
 @pytest.fixture(scope='module')
-def grid_coordinates(centre_deg=(0., 0.)):
-    """Return tuple of coordinates in deg mapping out a regular grid."""
-    n_side = 50
-    span = 20 * u.arcmin
-    x_width = span.to(u.deg).value
+def grid_coordinates():
+    def make_grid_coordinates(centre_deg=(0., 0.)):
+        """Return tuple of coordinates in deg mapping out a regular grid."""
+        n_side = 50
+        span = 20 * u.arcmin
+        x_width = span.to(u.deg).value
+        return get_grid_coordinates(n_side, centre_deg, x_width)
 
-    return get_grid_coordinates(n_side, centre_deg, x_width)
+    return make_grid_coordinates
 
 
-def test_tangent_plane_projection_roundtrip():
+def test_tangent_plane_projection_roundtrip(grid_coordinates):
     """Transform from RA/Dec to tangent plane and back. Check that input is recovered."""
     centre_deg = (80., -70.)   # setting this to 0,0 fails because of 0,360 deg wrapping
     ra_deg, dec_deg = grid_coordinates(centre_deg=centre_deg)
@@ -43,7 +45,7 @@ def test_tangent_plane_projection_roundtrip():
     assert np.std(difference_modulus) < 1.e-13 #, 'Problem with tangent plane projection.')
 
 
-def test_project_to_tangent_plane():
+def test_project_to_tangent_plane(grid_coordinates):
     """Compare projection code built with astropy functions with independent implementation."""
     centre_deg = (80., -70.)  # setting this to 0,0 fails because of 0,360 deg wrapping
     ra_deg, dec_deg = grid_coordinates(centre_deg=centre_deg)
@@ -56,7 +58,7 @@ def test_project_to_tangent_plane():
     assert np.max(difference_modulus) < 1e-13
 
 
-def test_deproject_from_tangent_plane():
+def test_deproject_from_tangent_plane(grid_coordinates):
     """Compare projection code built with astropy functions with independent implementation."""
     centre_deg = (80., -70.)  # setting this to 0,0 fails because of 0,360 deg wrapping
     ra_deg, dec_deg = grid_coordinates(centre_deg=centre_deg)


### PR DESCRIPTION
These plotting updates come from problems found while investigating issues #1 and #71.

A summary of the changes made:
- Made NIRSpec MSA detector channel plotting possible by plotting the channels from the NRS_FULL apertures
- Removed `NotImplementedError` for `siaf.py` `plot_detector_channels() `
- Add ax argument to `aperture.py` and `siaf.py` `plot_detector_channels()`
- Renamed `plot_all_apertures()` `showchannels` argument to `detector_channels` in order to match `plot_main_apertures()`
- Updated labeling arguments to be more logical between the `siaf.py` and `aperture.py` `plot()` methods
- Updated `siaf.py plot()` docstring to have frame examples in lowercase since that's what the argument expects.