### PR TITLE
Package_data pointing in setup.py for HST data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ setup(
     ],
     tests_require=['pytest'],
     packages=find_packages(),
-    package_data={PACKAGENAME: ['prd_data/HST/*/*',
+    package_data={PACKAGENAME: ['prd_data/HST/*',
                                 'prd_data/JWST/*/*/*/*.xlsx',
                                 'prd_data/JWST/*/*/*/*.xml',
                                 'pre_delivery_data/*/*.*',

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ setup(
     ],
     tests_require=['pytest'],
     packages=find_packages(),
-    package_data={PACKAGENAME: ['prd_data/HST/*/*.dat',
+    package_data={PACKAGENAME: ['prd_data/HST/*/*',
                                 'prd_data/JWST/*/*/*/*.xlsx',
                                 'prd_data/JWST/*/*/*/*.xml',
                                 'pre_delivery_data/*/*.*',


### PR DESCRIPTION
In the `setup.py` file, the package_data list is pointing to `prd_data/HST/*/*.dat`. However, there are 2 problems with this line. 

1. Not all of the files in the HST directory end in `.dat`, and thus this line leaves those files out
2. This line contains an extra sub-directory. IE the file path should be  `prd_data/HST/*`, since this is where the files live and there is no extra directory beneath this anymore (I see that you put in a PR about this earlier today). 

I found this problem when I was running `Travis` for `WebbPSF`, and it failed because it couldn’t find the HST files (particualrly `amu.rep-Latest` which isn't a `.dat` file) and was failing. As a heads up, this is to some extent blocking our 0.8 release of WebbPSF.