### PR TITLE
Relax openpyxl version req to allow building conda package for python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         'matplotlib>=1.4.3',
         'lxml>=3.6.4',
         'scipy>=0.17',
-        'openpyxl==2.5.0',
+        'openpyxl>=2.5.0',
         'requests>=2.21.0'
     ],
     tests_require=['pytest'],

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         'matplotlib>=1.4.3',
         'lxml>=3.6.4',
         'scipy>=0.17',
-        'openpyxl>=2.5.0',
+        'openpyxl>=2.6.0',
         'requests>=2.21.0'
     ],
     tests_require=['pytest'],


### PR DESCRIPTION
The Astroconda package for pysiaf will not build for python 3.7 with the dependency `openpyxl` pinned to version `2.5.0`. This relaxes that constraint so the dependencies can be solved for the build.