### PR TITLE
implement transforms to/from sky coordinates

### DIFF
--- a/docs/pysiaf/index.rst
+++ b/docs/pysiaf/index.rst
@@ -84,6 +84,24 @@ Frame transformations (`det`, `sci`, `idl`, `tel` are supported frames)::
     # transform from Science frame to Ideal frame
     idl_x, idl_y = nis_cen.sci_to_idl(sci_x, sci_y)
 
+
+Using sky transforms
+********************
+Transformations to/from `sky` coordinates (RA, Dec) are also supported, but you have to first define and set an
+attitude matrix that represents the observatory orientation with respect to the celestial sphere. This can be done with
+`pysiaf.utils.rotations.attitude_matrix`::
+
+    # find attitude with some coordinates (v2,v3) pointed at (ra, dec) with a given pa
+    attmat = pysiaf.utils.rotations.attitude_matrix(v2, v3, ra, dec, pa)
+
+    # set that attitude for the transforms
+    nis_cen.set_attitude_matrix(attmat)
+
+    # transform from Science frame to Sky frame
+    sky_ra, sky_dec = nis_cen.sci_to_sky(sci_x, sci_y)
+
+Sky coordinates are given in units of degrees RA and Dec.
+
 Reporting Issues / Contributing
 ===============================
 Do you have feedback and feature requests? Is there something missing you would like to see? Please open a new issue or new pull request at https://github.com/spacetelescope/pysiaf for bugs, feedback, or new features you would like to see. If there is an issue you would like to work on, please leave a comment and we will be happy to assist. New contributions and contributors are very welcome! This package follows the STScI `Code of Conduct <https://github.com/spacetelescope/pysiaf/blob/master/CODE_OF_CONDUCT.md>`_ strives to provide a welcoming community to all of our users and contributors.

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -141,8 +141,23 @@ def plot_all_apertures(subarrays=True, showorigin=True, detector_channels=True, 
             aps.plot_detector_channels()
 
 
-def plot_main_apertures(label=False, darkbg=False, detector_channels=False, **kwargs):
-    """Plot main/master apertures."""
+def plot_main_apertures(label=False, darkbg=False, detector_channels=False, frame='tel',
+        attitude_matrix=None, **kwargs):
+    """Plot main/master apertures.
+
+    Parameters
+    ----------
+    frame : string
+        Either 'tel' or 'sky'. (It does not make sense to plot apertures from multiple instruments in any of the
+        other frames)
+    attitude_matrix : 3x3 ndarray
+        Rotation matrix representing observatory attitude. Needed for sky frame plots.
+
+    """
+
+    if frame not in ['tel', 'sky']:
+        raise ValueError("Only the tel or sky frames make sense for plot_main_apertures")
+
     if darkbg:
         col_imaging = 'aqua'
         col_coron = 'lime'
@@ -192,19 +207,24 @@ def plot_main_apertures(label=False, darkbg=False, detector_channels=False, **kw
 
     for aplist, col in zip([im_aps, coron_aps, msa_aps], [col_imaging, col_coron, col_msa]):
         for ap in aplist:
-            ap.plot(color=col, frame='tel', label=label, **kwargs)
+
+            if frame=='sky':
+                ap.set_attitude_matrix(attitude_matrix)
+
+            ap.plot(color=col, frame=frame, label=label, **kwargs)
             if detector_channels:
                 try:
-                    ap.plot_detector_channels('tel')
+                    ap.plot_detector_channels(frame)
                 except TypeError:
                     pass
 
-    # ensure V2 increases to the left
-    ax = pl.gca()
-    xlim = ax.get_xlim()
+    if frame=='tel':
+        # ensure V2 increases to the left
+        ax = pl.gca()
+        xlim = ax.get_xlim()
 
-    if xlim[0] < xlim[1]:
-        ax.set_xlim(xlim[::-1])
+        if xlim[0] < xlim[1]:
+            ax.set_xlim(xlim[::-1])
 
 
 def plot_master_apertures(**kwargs):


### PR DESCRIPTION
Following up our conversation in slack - this PR adds transformations to/from the `sky` coordinate system. The actual transforms are implemented via calls to the `rotations.sky_to_tel` and `tel_to_sky` transforms, wrapped into similarly named methods on the `Aperture` class. 

PR should be pretty self-explanatory, hopefully. I included some basic documentation and a unit test too. 