### PR TITLE
in aperture.plot, pass transform keyword through to fill 

### DIFF
--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -689,7 +689,9 @@ class Aperture(object):
                     horizontalalignment='center', rotation=label_rotation,
                     color=ax.lines[-1].get_color())
         if fill:
-            ax.fill(x2 * scale, y2 * scale, color=fill_color, zorder=-40, alpha=fill_alpha)
+            # If a transform kwarg is supplied, pass it through to the fill function too
+            transform_kw = kwargs.get('transform', None)
+            ax.fill(x2 * scale, y2 * scale, color=fill_color, zorder=-40, alpha=fill_alpha, transform=transform_kw)
 
         if title:
             ax.set_title("{0} frame".format(frame))


### PR DESCRIPTION
A small followup to PR #177: The `transform` keyword argument added to the `aperture.plot` function should also be passed through to the call to `ax.fill`. This makes the `fill=True` option work when a transform is set. 