### PR TITLE
Fix git security issue affecting CI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,6 +21,11 @@ jobs:
           - name: checkout repo
             uses: actions/checkout@v2
 
+          - name: Fix issue with repository ownership
+            run: |
+            echo $GITHUB_WORKSPACE
+            git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
           - name: custom action
             uses: spacetelescope/action-publish_to_pypi@master
             id: custom_action_0


### PR DESCRIPTION
Adding a command to the PublishtoPyPi CI action to handle new git security update here: https://github.community/t/environment-variable-github-workspace-unusuable-when-setting-environment-variables/17266 