### PR TITLE
Allow use to trigger CI workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [released]
+    types: [released, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
Add workflow dispatch to allow for manual triggering of publishtopypi CI