### PR TITLE
Update to use action-publish_to_pypi reusable workflow, which should fix git security issue

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,25 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-      name: Publish release to PyPI
-      env:
-        PYPI_USERNAME_STSCI_MAINTAINER: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
-        PYPI_PASSWORD_STSCI_MAINTAINER: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
-        PYPI_USERNAME_OVERRIDE: ${{ secrets.PYPI_USERNAME_OVERRIDE }}
-        PYPI_PASSWORD_OVERRIDE: ${{ secrets.PYPI_PASSWORD_OVERRIDE }}
-        PYPI_TEST: ${{ secrets.PYPI_TEST }}
-        INDEX_URL_OVERRIDE: ${{ secrets.INDEX_URL_OVERRIDE }}
-      runs-on: ubuntu-latest
-      steps:
-
-          # Check out the commit containing this workflow file.
-          - name: checkout repo
-            uses: actions/checkout@v2
-
-          - name: Fix issue with repository ownership
-            run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-          - name: custom action
-            uses: spacetelescope/action-publish_to_pypi@master
-            id: custom_action_0
+  publish:
+    uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
+    with:
+      test: false
+      build_platform_wheels: false # Set to true if your package contains a C extension
+    secrets:
+      user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
+      password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
+      test_password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}


### PR DESCRIPTION
This is a fix for https://jira.stsci.edu/browse/SPB-959, and additionally needs to wait for https://github.com/spacetelescope/action-publish_to_pypi/pull/20 to merge before it can be merged.

This pull request as well as the above referenced one were tested successfully in this action run: https://github.com/zanecodes/pysiaf/actions/runs/2314790714 (the failure to publish at the end is because my fork is intentionally not set up with the PyPI token to publish for real)