### PR TITLE
cache CI environment

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,21 @@
+# flake8 does not support pyproject.toml (https://github.com/PyCQA/flake8/issues/234)
+
+[flake8]
+select = F, W, E, C
+# We should set max line length lower eventually
+max-line-length = 130
+exclude =
+    docs,
+    .tox,
+    .eggs,
+    build
+ignore =
+    F401, # imported but unused
+    F821, # undefined name
+    F841, # local variable assigned but never used
+    E122, # continuation line missing indentation or outdented
+    E126, # continuation line over-indented for hanging indent
+    E127, # continuation line over-indented for visual indent
+    E402, # module level import not at top of file
+    E501, # line too long (103 > 79 characters)
+    E741, # ambiguous variable name

--- a/.flake8
+++ b/.flake8
@@ -10,12 +10,13 @@ exclude =
     .eggs,
     build
 ignore =
-    F401, # imported but unused
-    F821, # undefined name
-    F841, # local variable assigned but never used
-    E122, # continuation line missing indentation or outdented
-    E126, # continuation line over-indented for hanging indent
-    E127, # continuation line over-indented for visual indent
-    E402, # module level import not at top of file
-    E501, # line too long (103 > 79 characters)
-    E741, # ambiguous variable name
+    F401,F821,F841,E122,E126,E127,E402,E501,E741
+    # F401, # imported but unused
+    # F821, # undefined name
+    # F841, # local variable assigned but never used
+    # E122, # continuation line missing indentation or outdented
+    # E126, # continuation line over-indented for hanging indent
+    # E127, # continuation line over-indented for visual indent
+    # E402, # module level import not at top of file
+    # E501, # line too long (103 > 79 characters)
+    # E741, # ambiguous variable name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        python: [ "3.9", "3.10", "3.11" ]
+        os: [ ubuntu-latest ]
+        python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        include:
+          - os: macos-latest
+            python: "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,8 @@ name: pysiaf CI
 on: [ push, pull_request ]
 
 jobs:
-  style:
-    name: Code style checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: style-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install flake8
-      - run: pip freeze
-      - run: flake8
   test:
     name: test (${{ matrix.os }}, Python ${{ matrix.python }})
-    needs: [ style ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python: [ "3.9", "3.10", "3.11" ]
         include:
           - os: macos-latest
             python: "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,22 +3,62 @@
 
 name: pysiaf CI
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
-  build:
-
+  style:
+    name: Code style checks
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: 'pyproject.toml'
-    - run: pip install ".[test]"
-    - run: pytest
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: style-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+      - run: pip install flake8
+      - run: pip freeze
+      - run: flake8
+  test:
+    name: test (${{ matrix.os }}, Python ${{ matrix.python }})
+    needs: [ style ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python: [ "3.9", "3.10", "3.11" ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+      - run: python -m pip install . pytest pytest-xdist
+      - run: pip freeze
+      - run: pytest -n auto
+  test_with_coverage:
+    name: run tests with coverage
+    needs: [ test ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: test-coverage-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+      - run: pip install -e ".[test]" pytest-xdist pytest-cov
+      - run: pip freeze
+      - run: pytest -n auto --cov-report=xml --cov-report=term-missing --cov=.

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -17,10 +17,6 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            python: "3.7"
-          - os: macos-latest
-            python: "3.8"
-          - os: macos-latest
             python: "3.9"
           - os: macos-latest
             python: "3.10"

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,0 +1,38 @@
+
+name: Weekly cron
+
+on:
+  schedule:
+    # Weekly Monday 6AM build
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: test (${{ matrix.os }}, Python ${{ matrix.python }})
+    needs: [ style ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            python: "3.7"
+          - os: macos-latest
+            python: "3.8"
+          - os: macos-latest
+            python: "3.9"
+          - os: macos-latest
+            python: "3.10"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+      - run: python -m pip install . pytest pytest-xdist
+      - run: pip freeze
+      - run: pytest -n auto

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -20,6 +20,10 @@ jobs:
             python: "3.9"
           - os: macos-latest
             python: "3.10"
+          - os: ubuntu-latest
+            python: "3.12-dev"
+          - os: macos-latest
+            python: "3.12-dev"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
<img width="863" alt="image" src="https://user-images.githubusercontent.com/16024299/225132052-d701e145-4f94-431d-bb06-eef161a8fc3d.png">

This PR does the following:
- expand test matrix (4 Python versions x 2 operating systems)
- ~add `.flake8` for Flake8 configuration~
- ~apply formatting to codebase to satisfy `ruff` checks~
- runs additional MacOS jobs on a weekly scheduled workflow