### PR TITLE
Remove usage of `pkg_resources`

### DIFF
--- a/pysiaf/__init__.py
+++ b/pysiaf/__init__.py
@@ -10,12 +10,7 @@ import requests
 # Configure logging
 logger = logging.getLogger(__name__)
 
-from pkg_resources import get_distribution, DistributionNotFound
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = 'unknown'
+from .version import __version__
 
 from .aperture import Aperture, HstAperture, JwstAperture, RomanAperture
 from .constants import JWST_PRD_VERSION, JWST_PRD_DATA_ROOT, JWST_PRD_DATA_ROOT_EXCEL, HST_PRD_VERSION, \


### PR DESCRIPTION
`pkg_resources` was deprecated way back in `python 3.10` for removal in `python 3.12`. Since this package is using dynamic versioning from  `setuptools_scm` it should be loading its version from the `setuptools_scm` generated file not via `pkg_resources`.

This PR removes the use of `pkg_resources` and instead loads version information from the file generated by `setuptools_scm` as part of package install.