### PR TITLE
Fix deprecation warnings from importlib and numpy

### DIFF
--- a/pysiaf/iando/read.py
+++ b/pysiaf/iando/read.py
@@ -641,8 +641,8 @@ def read_roman_siaf(siaf_file=None):
         from pysiaf import specpars
 
         if not siaf_file:
-            with importlib_resources.path('pysiaf.prd_data.Roman', 
-                                          'roman_siaf.xml') as siaf_file:
+            source = importlib_resources.files('pysiaf.prd_data.Roman').joinpath('roman_siaf.xml')
+            with importlib_resources.as_file(source) as siaf_file:
                 siaf_file = str(siaf_file)
         else:
                 siaf_file = str(siaf_file)

--- a/pysiaf/tests/test_polynomial.py
+++ b/pysiaf/tests/test_polynomial.py
@@ -17,9 +17,9 @@ def makeup_polynomial(order = 5):
     a = np.zeros(terms)
 
     np.random.seed(seed=1)
-    a[1] = 0.05 + 0.01 * np.random.rand(1)
+    a[1] = 0.05 + 0.01 * np.random.rand()
     np.random.seed(seed=2)
-    a[2] = 0.0001 * np.random.rand(1)
+    a[2] = 0.0001 * np.random.rand()
     np.random.seed(seed=3)
     a[3:6] = 1.0e-7 * np.random.rand(3)
     np.random.seed(seed=4)

--- a/pysiaf/utils/polynomial.py
+++ b/pysiaf/utils/polynomial.py
@@ -545,7 +545,7 @@ def prepend_rotation_to_polynomial(a, theta, verbose=False):
                 for j in range(m-n-mu, m-mu+1):
                     factor = (-1)**(m-n-mu) * choose(m-j, mu) * choose(j, m-n-mu)
                     cosSin = c**(j+2*mu-m+n) * s**(2*m-2*mu-j-n)
-                    atrotate[m, n] = atrotate[m, n] + factor * cosSin * at[m, j]
+                    atrotate[m, n] = np.squeeze(atrotate[m, n] + factor * cosSin * at[m, j])
                     if verbose:
                         print(m, n, j, factor, 'cos^', j+2*mu-m+n, 'sin^', 2*m-2*mu-j-n, ' A', m, j)
     # Put back in linear layout


### PR DESCRIPTION
This PR fixes a few deprecation warnings: 

1. Replaces the deprecated `importlib.resources.path` method with the new `files()` API 

2. Drops the `1` in `numpy.random.rand(1)`, and calls `squeeze` to resolve a similar issue where length-one vectors are being made where the result is expected to be scalar, since numpy 1.25:
```
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, 
and will error in future. Ensure you extract a single element from your array 
before performing this operation. (Deprecated NumPy 1.25.)
```

Closes https://github.com/spacetelescope/pysiaf/issues/360

