### PR TITLE
Fix for generate_nircam deprecation warnings

### DIFF
--- a/generate/generate_nircam.py
+++ b/generate/generate_nircam.py
@@ -206,10 +206,10 @@ for AperName in aperture_name_list:
                 ):
                     # see https://jira.stsci.edu/browse/JWSTSIAF-77
                     sca_name += "335R430R"
-                v2_offset = float(
+                v2_offset = np.ndarray.item(
                     wedge_offsets["v2_offset"][wedge_offsets["name"] == sca_name]
                 )
-                v3_offset = float(
+                v3_offset = np.ndarray.item(
                     wedge_offsets["v3_offset"][wedge_offsets["name"] == sca_name]
                 )
                 aperture.V2Ref += v2_offset


### PR DESCRIPTION
Changed 2 instances of float() being applied to arrays to numpy.ndarray.item() that were respponsible for deprecation warnings in generate_nircam.py.

Verified that the results for v2_offset and v3_offset were identical after the change.

old:
v2_offset 1.765293
v3_offset 40.1731467
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 1.585703
v3_offset 40.1257254
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 1.765293
v3_offset 40.1731467
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 1.585703
v3_offset 40.1257254
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 1.585703
v3_offset 40.1257254

new:
v2_offset 1.765293
v3_offset 40.1731467
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 1.585703
v3_offset 40.1257254
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 1.765293
v3_offset 40.1731467
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 1.585703
v3_offset 40.1257254
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 2.2208058
v3_offset 47.5127381
v2_offset 1.585703
v3_offset 40.1257254

