### PR TITLE
refactor part of plot_main_apertures to get_main_apertures

### DIFF
--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -149,35 +149,25 @@ def plot_all_apertures(subarrays=True, showorigin=True, detector_channels=True, 
             aps.plot_detector_channels()
 
 
-def plot_main_apertures(label=False, darkbg=False, detector_channels=False, frame='tel',
-        attitude_matrix=None, mission='jwst', **kwargs):
-    """Plot main/master apertures.
+def get_main_apertures(mission='jwst', frame='tel', **kwargs):
+    """ Return lists of main apertures, sorted into apertures for imaging, spectroscopy, and coronagraphy
+
+    The "main" apertures" per each observatory and instrument are defined in hard-coded lists within
+    this function. In general this includes the major instrument imaging detectors, spectrograph slits,
+    coronagraph apertures, etc.
+
+    This is used in plot_main_apertures, but is provided here as a separate function since these
+    lists of main apertures can be useful in other contexts as well.
+
+    Returns 3 lists of pysiaf Aperture instances
 
     Parameters
     ----------
-    frame : string
-        Either 'tel' or 'sky'. (It does not make sense to plot apertures from multiple instruments in any of the
-        other frames)
-    attitude_matrix : 3x3 ndarray
-        Rotation matrix representing observatory attitude. Needed for sky frame plots.
     mission : str
         observatory name, one of 'JWST', 'HST', or 'Roman'. Case insensitive.
 
     """
-
-    if frame not in ['tel', 'sky']:
-        raise ValueError("Only the tel or sky frames make sense for plot_main_apertures")
-
     if mission.upper() == 'JWST':
-        if darkbg:
-            col_imaging = 'aqua'
-            col_coron = 'lime'
-            col_msa = 'violet'
-        else:
-            col_imaging = 'blue'
-            col_coron = 'green'
-            col_msa = 'magenta'
-
         nircam = Siaf('NIRCam')
         niriss = Siaf('NIRISS')
         fgs = Siaf('FGS')
@@ -192,7 +182,6 @@ def plot_main_apertures(label=False, darkbg=False, detector_channels=False, fram
             fgs['FGS1_FULL'],
             fgs['FGS2_FULL']
         ]
-
         for letter in ['A', 'B']:
             for num in range(5):
                 im_aps.append(nircam['NRC{}{}_FULL'.format(letter, num + 1)])
@@ -213,44 +202,87 @@ def plot_main_apertures(label=False, darkbg=False, detector_channels=False, fram
             miri['MIRIM_MASK1550'],
             miri['MIRIM_MASKLYOT']
         ]
-        msa_aps = [nirspec['NRS_FULL_MSA' + str(n + 1)] for n in range(4)]
-        msa_aps.append(nirspec['NRS_S1600A1_SLIT'])  # square aperture
-    elif mission.upper() == 'HST':
-       if darkbg:
-            col_imaging = 'lightgray'
-            col_coron = 'lime'  # n/a
-            col_msa = 'violet'  # n/a
-       else:
-            col_imaging = 'gray'
-            col_coron = 'green'
-            col_msa = 'magenta'
 
+        spectra_aps = [nirspec['NRS_FULL_MSA' + str(n + 1)] for n in range(4)]
+        for spec_ap_name in ['NRS_S1600A1_SLIT', 'NRS_S200A1_SLIT', 'NRS_S200A2_SLIT', 'NRS_S400A1_SLIT', 'NRS_FULL_IFU']:
+            spectra_aps.append(nirspec[spec_ap_name])
+
+        for i in range(4):
+            spectra_aps.append(miri[f'MIRIFU_CHANNEL{i+1}A'])
+    elif mission.upper() == 'HST':
        hst_siaf = Siaf('hst')
        hst_si_apnames = ['FGS1', 'FGS2', 'FGS3', 'JWFC1', 'JWFC2', 'IUVIS1', 'IUVIS2', 'OV50', 'ON25', 'OF25']
        # TODO: add COS 'LNPSA', 'LFPSA'; once pysiaf.plot() supports circular apertures
        im_aps = [hst_siaf.apertures[n] for n in hst_si_apnames]
 
        coron_aps = []
-       msa_aps = []
+       spectra_aps = []
 
+    elif mission.upper() == 'ROMAN':
+        roman_siaf = Siaf('roman')
+
+        im_aps = [roman_siaf.apertures[f'WFI{i+1:02d}_FULL'] for i in range(18)]
+        coron_aps = [roman_siaf.apertures['CGI_CEN'], ]
+        spectra_aps = []
+
+    return im_aps, spectra_aps, coron_aps
+
+
+def plot_main_apertures(label=False, darkbg=False, detector_channels=False, frame='tel',
+        attitude_matrix=None, mission='jwst', **kwargs):
+    """Plot main/master apertures
+
+    Note, distinct colors are used to indicate imaging, spectroscopy, and coronagraphic
+    apertures. Colors also distinguish between apertures for different missions, for cases
+    in which HST, JWST, and Roman focal planes might be plotted together.
+
+    Parameters
+    ----------
+    frame : string
+        Either 'tel' or 'sky'. (It does not make sense to plot apertures from multiple instruments in any of the
+        other frames)
+    attitude_matrix : 3x3 ndarray
+        Rotation matrix representing observatory attitude. Needed for sky frame plots.
+    mission : str
+        observatory name, one of 'JWST', 'HST', or 'Roman'. Case insensitive.
+
+    """
+
+    if frame not in ['tel', 'sky']:
+        raise ValueError("Only the tel or sky frames make sense for plot_main_apertures")
+
+    im_aps, spectra_aps, coron_aps = get_main_apertures(mission=mission, frame=frame)
+
+    if mission.upper() == 'JWST':
+        if darkbg:
+            col_imaging = 'aqua'
+            col_coron = 'lime'
+            col_spectra = 'violet'
+        else:
+            col_imaging = 'blue'
+            col_coron = 'green'
+            col_spectra = 'magenta'
+    elif mission.upper() == 'HST':
+       if darkbg:
+            col_imaging = 'lightgray'
+            col_coron = 'lime'  # n/a
+            col_spectra = 'violet'  # n/a
+       else:
+            col_imaging = 'gray'
+            col_coron = 'green'
+            col_spectra = 'magenta'
     elif mission.upper() == 'ROMAN':
         if darkbg:
             col_imaging = 'orange'
             col_coron = 'aqua'
-            col_msa = 'violet'  # n/a
+            col_spectra = 'violet'  # n/a
         else:
             col_imaging = 'orange'
             col_coron = 'teal'
-            col_msa = 'magenta'
-
-        roman_siaf = Siaf('roman')
-        im_aps = [roman_siaf.apertures[f'WFI{i+1:02d}_FULL'] for i in range(18)]
-        coron_aps = [roman_siaf.apertures['CGI_CEN'], ]
-
-        msa_aps = []
+            col_spectra = 'magenta'
 
 
-    for aplist, col in zip([im_aps, coron_aps, msa_aps], [col_imaging, col_coron, col_msa]):
+    for aplist, col in zip([im_aps, coron_aps, spectra_aps], [col_imaging, col_coron, col_spectra]):
         for ap in aplist:
 
             if frame=='sky':
@@ -522,4 +554,3 @@ class Siaf(ApertureCollection):
 
         for ap in self._getFullApertures():
             ap.plot_detector_channels(frame=frame, ax=ax)
-            

--- a/pysiaf/tests/test_aperture.py
+++ b/pysiaf/tests/test_aperture.py
@@ -11,8 +11,9 @@ import numpy as np
 import pytest
 
 from ..iando import read
-from ..siaf import Siaf, get_jwst_apertures
+from ..siaf import Siaf, get_jwst_apertures, get_main_apertures
 from ..utils.tools import get_grid_coordinates
+from ..aperture import Aperture
 
 @pytest.fixture(scope='module')
 def siaf_objects():
@@ -284,3 +285,13 @@ def test_jwst_sky_transformations(verbose=False):
     # test to/from detector coords, to test all the intermediate transforms too
     # Below still fails
     #assert np.allclose(fgs_aperture.sky_to_det(*fgs_aperture.det_to_sky(d1,d2)), (d1,d2)), "sky_to_det(det_to_sky) was not an identity"
+
+
+def test_get_main_apertures():
+
+    for mission in ['hst', 'jwst', 'roman']:
+        im_aps, spectra_aps, coron_aps = get_main_apertures(mission=mission)
+
+        for ap_list in [im_aps, spectra_aps, coron_aps]:
+            for ap in ap_list:
+                assert isinstance(ap, Aperture), "This should be a list of apertures"

--- a/pysiaf/tests/test_plotting.py
+++ b/pysiaf/tests/test_plotting.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as pl
 import pytest
 
 from ..constants import JWST_TEMPORARY_DATA_ROOT
-from ..siaf import Siaf, plot_master_apertures
+from ..siaf import Siaf, plot_master_apertures, plot_main_apertures
 
 # @pytest.mark.skip(reason="Need to figure out how to set backend")
 def test_aperture_plotting():
@@ -68,3 +68,20 @@ def test_aperture_plotting():
         pl.savefig(fig_name, transparent=True, bbox_inches='tight', pad_inches=0.05)
 
     assert os.path.isfile(fig_name)
+
+
+def test_plot_main_apertures():
+    save_plot = True
+    plot_dir = os.path.join(JWST_TEMPORARY_DATA_ROOT)
+    if not os.path.isdir(plot_dir):
+        os.makedirs(plot_dir)
+
+    missions = ['hst', 'jwst', 'roman']
+    for mission in missions:
+        pl.figure()
+        plot_main_apertures(mission=mission)
+
+        fig_name = os.path.join(plot_dir, f'main_apertures_{mission}.png')
+        pl.savefig(fig_name, transparent=True, bbox_inches='tight', pad_inches=0.05)
+
+        assert os.path.isfile(fig_name)


### PR DESCRIPTION
The existing `plot_main_apertures` function has useful lists defining the main apertures per observatory. This PR refactors the code to pull the definition of those lists out into a separate `get_main_apertures` function. This allows accessing and using the list of main apertures in other contexts outside of just the `plot_main_apertures` function. 


Example usage: 
```
In [2]: import pysiaf

In [3]: im_aps, spec_aps, coron_aps = pysiaf.siaf.get_main_apertures('jwst')

In [4]: im_aps
Out[4]:
[<pysiaf.Aperture object AperName=NRCA5_FULL >,
 <pysiaf.Aperture object AperName=NRCB5_FULL >,
 <pysiaf.Aperture object AperName=NIS_CEN >,
 <pysiaf.Aperture object AperName=MIRIM_ILLUM >,
 <pysiaf.Aperture object AperName=FGS1_FULL >,
 <pysiaf.Aperture object AperName=FGS2_FULL >,
 <pysiaf.Aperture object AperName=NRCA1_FULL >,
 <pysiaf.Aperture object AperName=NRCA2_FULL >,
 <pysiaf.Aperture object AperName=NRCA3_FULL >,
 <pysiaf.Aperture object AperName=NRCA4_FULL >,
 <pysiaf.Aperture object AperName=NRCA5_FULL >,
 <pysiaf.Aperture object AperName=NRCB1_FULL >,
 <pysiaf.Aperture object AperName=NRCB2_FULL >,
 <pysiaf.Aperture object AperName=NRCB3_FULL >,
 <pysiaf.Aperture object AperName=NRCB4_FULL >,
 <pysiaf.Aperture object AperName=NRCB5_FULL >]

```