### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
 ]
 classifiers = [
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering :: Astronomy",
@@ -21,6 +20,7 @@ dependencies = [
     "requests>=2.26.0",
     "scipy>=1.7.2",
 ]
+license-files = ["LICENSE.md"]
 dynamic = [
     "version",
 ]
@@ -29,10 +29,6 @@ requires-python = ">=3.10"
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
-
-[project.license]
-file = "LICENSE.md"
-content-type = "text/plain"
 
 [project.urls]
 documentation = "https://pysiaf.readthedocs.io/en/latest/"


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))