### PR TITLE
Roman Prelaunch Changes

### DIFF
--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -47,10 +47,10 @@ from .constants import HST_PRD_DATA_ROOT, HST_PRD_VERSION
 # shorthands for supported coordinate systems
 FRAMES = ('det', 'sci', 'idl', 'tel', 'raw', 'sky')
 
-# list of attributes for the distortion coefficients up to degree 20
+# list of attributes for the distortion coefficients up to degree 9
 POLYNOMIAL_COEFFICIENT_NAMES = 'Sci2IdlX Sci2IdlY Idl2SciX Idl2SciY'.split()
 DISTORTION_ATTRIBUTES = []
-for i in range(20 + 1):
+for i in range(9 + 1):
     for j in np.arange(i + 1):
         for name in POLYNOMIAL_COEFFICIENT_NAMES:
             DISTORTION_ATTRIBUTES.append('{}{:d}{:d}'.format(name, i, j))

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -47,10 +47,10 @@ from .constants import HST_PRD_DATA_ROOT, HST_PRD_VERSION
 # shorthands for supported coordinate systems
 FRAMES = ('det', 'sci', 'idl', 'tel', 'raw', 'sky')
 
-# list of attributes for the distortion coefficients up to degree 9
+# list of attributes for the distortion coefficients up to degree 20
 POLYNOMIAL_COEFFICIENT_NAMES = 'Sci2IdlX Sci2IdlY Idl2SciX Idl2SciY'.split()
 DISTORTION_ATTRIBUTES = []
-for i in range(9 + 1):
+for i in range(20 + 1):
     for j in np.arange(i + 1):
         for name in POLYNOMIAL_COEFFICIENT_NAMES:
             DISTORTION_ATTRIBUTES.append('{}{:d}{:d}'.format(name, i, j))
@@ -916,7 +916,6 @@ class Aperture(object):
 
         number_of_coefficients = polynomial.number_of_coefficients(degree)
         all_keys = self.__dict__.keys()
-        print(self.__dict__)
 
         for axis in ['X', 'Y']:
             coeff_keys = np.array([c for c in all_keys if label + axis in c])

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -47,10 +47,10 @@ from .constants import HST_PRD_DATA_ROOT, HST_PRD_VERSION
 # shorthands for supported coordinate systems
 FRAMES = ('det', 'sci', 'idl', 'tel', 'raw', 'sky')
 
-# list of attributes for the distortion coefficients up to degree 9
+# list of attributes for the distortion coefficients up to degree 5
 POLYNOMIAL_COEFFICIENT_NAMES = 'Sci2IdlX Sci2IdlY Idl2SciX Idl2SciY'.split()
 DISTORTION_ATTRIBUTES = []
-for i in range(9 + 1):
+for i in range(5 + 1):
     for j in np.arange(i + 1):
         for name in POLYNOMIAL_COEFFICIENT_NAMES:
             DISTORTION_ATTRIBUTES.append('{}{:d}{:d}'.format(name, i, j))
@@ -479,15 +479,8 @@ class Aperture(object):
         number_of_coefficients = polynomial.number_of_coefficients(self.Sci2IdlDeg)
         cdict = {}
         for seed in 'Sci2IdlX Sci2IdlY Idl2SciX Idl2SciY'.split():
-            for s in DISTORTION_ATTRIBUTES:
-                vals = []
-                if seed in s:
-                    try:
-                        vals.append(getattr(self, s))
-                    except AttributeError:
-                        pass
-            cdict[seed] = np.array(vals)[0:number_of_coefficients]
-            
+            cdict[seed] = np.array([getattr(self, s) for s in DISTORTION_ATTRIBUTES if
+                                   seed in s])[0:number_of_coefficients]
         return cdict
 
 

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -479,8 +479,15 @@ class Aperture(object):
         number_of_coefficients = polynomial.number_of_coefficients(self.Sci2IdlDeg)
         cdict = {}
         for seed in 'Sci2IdlX Sci2IdlY Idl2SciX Idl2SciY'.split():
-            cdict[seed] = np.array([getattr(self, s) for s in DISTORTION_ATTRIBUTES if
-                                   seed in s])[0:number_of_coefficients]
+            for s in DISTORTION_ATTRIBUTES:
+                vals = []
+                if seed in s:
+                    try:
+                        vals.append(getattr(self, s))
+                    except AttributeError:
+                        pass
+            cdict[seed] = np.array(vals)[0:number_of_coefficients]
+            
         return cdict
 
 

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -47,10 +47,10 @@ from .constants import HST_PRD_DATA_ROOT, HST_PRD_VERSION
 # shorthands for supported coordinate systems
 FRAMES = ('det', 'sci', 'idl', 'tel', 'raw', 'sky')
 
-# list of attributes for the distortion coefficients up to degree 5
+# list of attributes for the distortion coefficients up to degree 9
 POLYNOMIAL_COEFFICIENT_NAMES = 'Sci2IdlX Sci2IdlY Idl2SciX Idl2SciY'.split()
 DISTORTION_ATTRIBUTES = []
-for i in range(5 + 1):
+for i in range(9 + 1):
     for j in np.arange(i + 1):
         for name in POLYNOMIAL_COEFFICIENT_NAMES:
             DISTORTION_ATTRIBUTES.append('{}{:d}{:d}'.format(name, i, j))
@@ -916,6 +916,7 @@ class Aperture(object):
 
         number_of_coefficients = polynomial.number_of_coefficients(degree)
         all_keys = self.__dict__.keys()
+        print(self.__dict__)
 
         for axis in ['X', 'Y']:
             coeff_keys = np.array([c for c in all_keys if label + axis in c])

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -689,7 +689,7 @@ class Aperture(object):
                     horizontalalignment='center', rotation=label_rotation,
                     color=ax.lines[-1].get_color())
         if fill:
-            if self.observatory == "JWST":
+            if self.observatory in ["JWST", 'Roman']:
                 # If a transform kwarg is supplied, pass it through to the fill function too
                 transform_kw = kwargs.get('transform', None)
                 ax.fill(x2 * scale, y2 * scale, color=fill_color, zorder=-40, alpha=fill_alpha, transform=transform_kw) 
@@ -703,7 +703,7 @@ class Aperture(object):
             x_ref, y_ref = self.reference_point(frame)
             ax.plot([x_ref], [y_ref], marker='+', color=ax.lines[-1].get_color())
 
-        if (frame == 'tel') and (self.observatory == 'JWST'):
+        if (frame == 'tel') and (self.observatory in ['JWST', 'Roman']):
             # ensure V2 increases to the left
             xlim = ax.get_xlim()
             if xlim[0] < xlim[1]:

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -689,7 +689,7 @@ class Aperture(object):
                     horizontalalignment='center', rotation=label_rotation,
                     color=ax.lines[-1].get_color())
         if fill:
-            if self.observatory in ["JWST", 'Roman']:
+            if self.observatory in ["JWST", "Roman"]:
                 # If a transform kwarg is supplied, pass it through to the fill function too
                 transform_kw = kwargs.get('transform', None)
                 ax.fill(x2 * scale, y2 * scale, color=fill_color, zorder=-40, alpha=fill_alpha, transform=transform_kw) 

--- a/pysiaf/iando/read.py
+++ b/pysiaf/iando/read.py
@@ -692,7 +692,7 @@ def read_roman_siaf(siaf_file=None):
                         value = int(node.text)
                     except (TypeError, ValueError) as e:
                         if node.tag == 'DetSciYAngle':
-                            value = np.int(float(node.text))
+                            value = int(float(node.text))
                         elif not node.text:
                             value = None
                         else:
@@ -717,6 +717,7 @@ def read_roman_siaf(siaf_file=None):
                     except TypeError:
                         print('{}: {}'.format(node.tag, node.text))
                         raise TypeError
+                print(f'{node.tag} = {value}')
                 setattr(roman_aperture, node.tag, value)
 
             apertures[roman_aperture.AperName] = roman_aperture

--- a/pysiaf/iando/read.py
+++ b/pysiaf/iando/read.py
@@ -699,7 +699,7 @@ def read_roman_siaf(siaf_file=None):
                             raise TypeError
                 elif node.tag in aperture.STRING_ATTRIBUTES:
                     value = node.text
-                elif node.tag in aperture.FLOAT_ATTRIBUTES:
+                elif (node.tag in aperture.FLOAT_ATTRIBUTES) or (node.tag in aperture.DISTORTION_ATTRIBUTES):
                     value = float(node.text)
                 # If it has children (which we can test by a simple boolean),
                 # then we need to get things out of it. The only time this will
@@ -717,7 +717,6 @@ def read_roman_siaf(siaf_file=None):
                     except TypeError:
                         print('{}: {}'.format(node.tag, node.text))
                         raise TypeError
-                print(f'{node.tag} = {value}')
                 setattr(roman_aperture, node.tag, value)
 
             apertures[roman_aperture.AperName] = roman_aperture

--- a/pysiaf/iando/read.py
+++ b/pysiaf/iando/read.py
@@ -699,7 +699,7 @@ def read_roman_siaf(siaf_file=None):
                             raise TypeError
                 elif node.tag in aperture.STRING_ATTRIBUTES:
                     value = node.text
-                elif (node.tag in aperture.FLOAT_ATTRIBUTES) or (node.tag in aperture.DISTORTION_ATTRIBUTES):
+                elif node.tag in aperture.FLOAT_ATTRIBUTES:
                     value = float(node.text)
                 # If it has children (which we can test by a simple boolean),
                 # then we need to get things out of it. The only time this will

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -31,6 +31,7 @@ from .iando import read
 
 # from soc_roman_tools
 import sys
+import os
 import ast
 import importlib.resources as importlib_resources
 from xml.etree import ElementTree as ET
@@ -387,7 +388,14 @@ class Siaf(ApertureCollection):
             self.apertures = read.read_hst_siaf()
             self.observatory = 'HST'
         elif self.instrument == 'roman':
-            self.apertures = read.read_roman_siaf()
+            if basepath:
+                if filename:
+                    siaf_file = os.path.join(basepath, filename)
+                else:
+                    siaf_file = os.path.join(basepath, 'roman_siaf.xml')
+            else:
+                siaf_file = None
+            self.apertures = read.read_roman_siaf(siaf_file=siaf_file)
             self.observatory = 'Roman'
         else:
             self.apertures = read.read_jwst_siaf(self.instrument, filename=filename, basepath=basepath)


### PR DESCRIPTION
This PR urgently addresses an issue for Roman DMS such that they can specify a file location for a Roman SIAF XML file that is not the pysiaf package data version. 

~I have also included raising the distortion polynomial order from 5 to 9. It is unclear if this is going to be necessary for Roman as we are still testing the latest SIAF, but up to degree 9 works without issues in the pysiaf code. Degrees above 9 will cause exceptions due to the format of the coefficient tag names in the SIAF XML definition for JWST and Roman.~ Useful to know for later, but for now seems to cause CI failures. The urgent bit is the DMS fix, so can investigate later a way to get this working if needed.

I also encountered a bug leftover from the numpy 2.0 upgrade that caused an issue in line 695 of iando/read.py. Changing from np.int() to simply int() fixes the problem in the event the conditional is triggered.