### PR TITLE
Update supporting romancal B22.1 release build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "astropy >= 7.0.0, < 8.0.0",
-    "lxml >= 6.0.0, < 7.0.0",
-    "matplotlib >= 3.10.0, < 4.0.0",
-    "numpy >= 2.0.0, < 3.0.0",
-    "openpyxl >= 3.1.5, < 4.0.0",
-    "requests >= 2.32.0, < 3.0.0",
-    "scipy >= 1.15.3, < 2.0.0",
+    "astropy >= 7.0.0",
+    "lxml >= 6.0.0",
+    "matplotlib >= 3.10.0",
+    "numpy >= 2.0.0",
+    "openpyxl >= 3.1.5",
+    "requests >= 2.32.0",
+    "scipy >= 1.15.3",
 ]
 license-files = ["LICENSE.md"]
 dynamic = [
@@ -74,6 +74,7 @@ pysiaf = [
     "source_data/*.txt",
     "tests/test_data/*/*/*/*.fits",
     "tests/test_data/*/*/*/*.txt",
+    "prd_data/Roman/roman_siaf.xml",
 ]
 
 [tool.pytest.ini_options]

--- a/pysiaf/__init__.py
+++ b/pysiaf/__init__.py
@@ -2,7 +2,6 @@
 
 """
 
-from __future__ import absolute_import, print_function, division
 import logging
 import re
 import requests

--- a/pysiaf/aperture.py
+++ b/pysiaf/aperture.py
@@ -42,7 +42,7 @@ import matplotlib
 from .utils import rotations, projection, polynomial
 from .utils.tools import an_to_tel, tel_to_an
 from .iando import read
-from .constants import HST_PRD_DATA_ROOT, HST_PRD_VERSION
+#from .constants import HST_PRD_DATA_ROOT, HST_PRD_VERSION
 
 # shorthands for supported coordinate systems
 FRAMES = ('det', 'sci', 'idl', 'tel', 'raw', 'sky')
@@ -1880,6 +1880,7 @@ class HstAperture(Aperture):
 
             if (method == 'spherical_transformation') and (output_coordinates == 'tangent_plane'):
                 # tangent plane projection using tel boresight
+                # v2/v3_spherical_arcsec never defined
                 v2_tangent_deg, v3_tangent_deg = projection.project_to_tangent_plane(v2_spherical_arcsec * u.arcsec.to(u.deg),
                                                                                      v3_spherical_arcsec * u.arcsec.to(u.deg), 0.0, 0.0)
                 v2_arcsec, v3_arcsec = v2_tangent_deg*3600., v3_tangent_deg*3600.

--- a/pysiaf/iando/write.py
+++ b/pysiaf/iando/write.py
@@ -11,7 +11,6 @@ Authors
 
 """
 
-import ast
 import os
 
 import numpy as np

--- a/pysiaf/siaf.py
+++ b/pysiaf/siaf.py
@@ -19,22 +19,16 @@ References
     (https://github.com/mperrin/jwxml).
 
 """
-from __future__ import absolute_import, print_function, division
 from collections import OrderedDict
 import re
-
+import numpy as np 
 from astropy.table import Table
-import numpy as np
 import matplotlib.pyplot as pl
 
 from .iando import read
 
 # from soc_roman_tools
-import sys
 import os
-import ast
-import importlib.resources as importlib_resources
-from xml.etree import ElementTree as ET
 
 
 

--- a/pysiaf/specpars.py
+++ b/pysiaf/specpars.py
@@ -1,3 +1,9 @@
+from xml.etree import ElementTree as ET
+import ast
+import numpy as np
+import importlib.resources as importlib_resources
+
+
 class SpecPars():
     """
     Class to contain the aXe-like parameterization of spectroscopic


### PR DESCRIPTION
- remove the upper pins on the dependency list
- remove unused imports
- update package data to include the roman siaf

Tests run and pass. 
manual import of roman siaf file given basepath works

